### PR TITLE
update WebAudio call

### DIFF
--- a/build/gsynth.js
+++ b/build/gsynth.js
@@ -55,7 +55,7 @@ gsynth = {};
     },
 
     _createAudioNode: function(){
-      this.node = this.context.createJavaScriptNode(1024, 1, 1);
+      this.node = this.context.createScriptProcessor(1024, 1, 1);
 
       var self = this;
 

--- a/js/SoundOutputBuffer.js
+++ b/js/SoundOutputBuffer.js
@@ -54,7 +54,7 @@
     },
 
     _createAudioNode: function(){
-      this.node = this.context.createJavaScriptNode(1024, 1, 1);
+      this.node = this.context.createScriptProcessor(1024, 1, 1);
 
       var self = this;
 


### PR DESCRIPTION
`context.createJavaScriptNode()` method is now called `createScriptProcessor`. Updated
